### PR TITLE
metadata, multiple recipients, and attachment implemented

### DIFF
--- a/nb2mail/__init__.py
+++ b/nb2mail/__init__.py
@@ -93,6 +93,8 @@ class MailExporter(TemplateExporter):
         else:
             if nb['metadata']['nb2mail'].get('recipients') != None:
                 msg['To'] = json.dumps(nb['metadata']['nb2mail'].get('recipients'))
+            if nb['metadata']['nb2mail'].get('from') != None:
+                msg['From'] = nb['metadata']['nb2mail'].get('from')
             if nb['metadata']['nb2mail'].get('subject') != None:
                 msg['Subject'] = nb['metadata']['nb2mail'].get('subject')
 


### PR DESCRIPTION
Using the notebook's metadata you can now:
- Send to multiple recipients.
- Send email attachments.
- Set subject rather than using file_name as default
- Set from address rather than using account email as default

You can set the metadata by adding in a new key "nb2mail" as such:
"nb2mail": {
    "attachments": [
      "business_report_attachment.xlsx"
    ],
    "from": "reports@example.com",
    "recipients": [
      "person1@example.com",
      "person2@example.com"
    ],
    "subject": "Business Report"
  }