### PR TITLE
Add extension to default template name

### DIFF
--- a/nb2mail/__init__.py
+++ b/nb2mail/__init__.py
@@ -64,7 +64,7 @@ class MailExporter(TemplateExporter):
 
     @default('template_file')
     def _template_file_default(self):
-        return 'mail'
+        return 'mail.tpl'
 
     output_mimetype = 'multipart/mixed'
 


### PR DESCRIPTION
Corresponding change to jupyter/nbconvert#639, adding an extension to the default template file.

https://github.com/jupyter/nbconvert/pull/639/