### PR TITLE
Make headers configurable in mail exporter

### DIFF
--- a/nb2mail/__init__.py
+++ b/nb2mail/__init__.py
@@ -166,9 +166,9 @@ class SendMailPostProcessor(PostProcessorBase):
             email = Parser().parse(f)
 
         if not self.recipient:
-            # Set recipients from notebook metadata
+            # Set recipients from .mail file
             # Multiple recipients can be comma seperated
-            self.recipient = ','.join(filter(None, [email.get('To', ''), email.get('Cc', '')]))
+            self.recipient = ','.join(filter(None, [email.get('To'), email.get('Cc')]))
         else:
             # Set To header from config
             email['To'] = self.recipient


### PR DESCRIPTION
* Expose the From, To, Cc and Subject headers as configuration parameters in `MailExporter`.
* Notebook metadata takes precedence over these configuration parameters.
* When sending mail, update mail headers to reflect actual recipients.

Refs #8 