### PR TITLE
fix default template

### DIFF
--- a/nb2mail/templates/mail.tpl
+++ b/nb2mail/templates/mail.tpl
@@ -1,4 +1,4 @@
-{% extends 'display_priority.tpl' %}
+{% extends 'base/display_priority.j2' %}
 
 
 {% block in_prompt %}

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='nb2mail',
-      version='0.8',
+      version='0.9',
       description='Convert notebooks to email',
       url='http://github.com/nfultz/nb2mail',
       download_url='https://github.com/nfultz/nb2mail/tarball/0.8',


### PR DESCRIPTION
nbcovert moved the original location of the display priority template. Related to issue: https://github.com/nfultz/nb2mail/issues/13

Working example of new mail.tpl without "none" at the top of the email.

![image](https://github.com/nfultz/nb2mail/assets/2526272/58fee677-4fbf-46a7-81c2-5a584d201081)
